### PR TITLE
Added support for fetching data of multiple files

### DIFF
--- a/src/main/kotlin/com/arnyminerz/escalaralcoiaicomtat/backend/server/endpoints/files/RequestFileEndpoint.kt
+++ b/src/main/kotlin/com/arnyminerz/escalaralcoiaicomtat/backend/server/endpoints/files/RequestFileEndpoint.kt
@@ -13,33 +13,51 @@ import io.ktor.server.application.call
 import io.ktor.server.plugins.origin
 import io.ktor.server.util.getValue
 import io.ktor.util.pipeline.PipelineContext
+import java.io.FileNotFoundException
 import java.nio.file.Files
 import java.security.MessageDigest
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.json.JSONObject
 
 object RequestFileEndpoint : EndpointBase() {
     private const val DEFAULT_HTTP_PORT = 80
 
     private val digest = MessageDigest.getInstance(MessageDigestAlgorithm.SHA_256)
 
-    override suspend fun PipelineContext<Unit, ApplicationCall>.endpoint() {
-        val uuid: String by call.parameters
-
-        val file = Storage.find(uuid) ?: return respondFailure(Errors.FileNotFound)
+    private suspend fun PipelineContext<Unit, ApplicationCall>.getDataFor(uuid: String): JSONObject {
+        val file = Storage.find(uuid) ?: throw FileNotFoundException("Could not find file with uuid $uuid")
         val downloadAddress = call.request.origin.let { p ->
             val port = p.serverPort.takeIf { it != DEFAULT_HTTP_PORT }?.let { ":$it" } ?: ""
             "${p.scheme}://${p.serverHost}$port/download/$uuid"
         }
         val size = withContext(Dispatchers.IO) { Files.size(file.toPath()) }
 
-        respondSuccess(
-            jsonOf(
-                "hash" to HashUtils.getCheckSumFromFile(digest, file),
-                "filename" to file.name,
-                "download" to downloadAddress,
-                "size" to size
-            )
+        return jsonOf(
+            "hash" to HashUtils.getCheckSumFromFile(digest, file),
+            "filename" to file.name,
+            "download" to downloadAddress,
+            "size" to size
         )
+    }
+
+    override suspend fun PipelineContext<Unit, ApplicationCall>.endpoint() {
+        val uuids: String by call.parameters
+        val list = uuids.split(",")
+
+        // It's impossible that "list" has size 0
+        try {
+            respondSuccess(
+                if (list.size <= 1) {
+                    getDataFor(uuids)
+                } else {
+                    jsonOf(
+                        "files" to list.map { getDataFor(it) }
+                    )
+                }
+            )
+        } catch (_: FileNotFoundException) {
+            respondFailure(Errors.FileNotFound)
+        }
     }
 }

--- a/src/main/kotlin/com/arnyminerz/escalaralcoiaicomtat/backend/server/plugins/Routing.kt
+++ b/src/main/kotlin/com/arnyminerz/escalaralcoiaicomtat/backend/server/plugins/Routing.kt
@@ -81,7 +81,7 @@ fun Application.configureEndpoints() {
         delete("/block/{blockId}") { DeleteBlockEndpoint.call(this) }
         patch("/block/{blockId}") { PatchBlockEndpoint.call(this) }
 
-        get("/file/{uuid}") { RequestFileEndpoint.call(this) }
+        get("/file/{uuids}") { RequestFileEndpoint.call(this) }
         get("/download/{uuid}") { DownloadFileEndpoint.call(this) }
 
         val enableImporter = EnvironmentVariables.Legacy.Importer.value


### PR DESCRIPTION
When using the `/file/{uuid}` endpoint, you can include multiple file UUIDs, separated by commas (`,`). The response will be given in a JSON array with key `files`.