### PR TITLE
Added UUID to response

### DIFF
--- a/src/main/kotlin/com/arnyminerz/escalaralcoiaicomtat/backend/server/endpoints/files/RequestFileEndpoint.kt
+++ b/src/main/kotlin/com/arnyminerz/escalaralcoiaicomtat/backend/server/endpoints/files/RequestFileEndpoint.kt
@@ -34,6 +34,7 @@ object RequestFileEndpoint : EndpointBase() {
         val size = withContext(Dispatchers.IO) { Files.size(file.toPath()) }
 
         return jsonOf(
+            "uuid" to uuid,
             "hash" to HashUtils.getCheckSumFromFile(digest, file),
             "filename" to file.name,
             "download" to downloadAddress,

--- a/src/test/kotlin/com/arnyminerz/escalaralcoiaicomtat/backend/server/endpoints/files/TestFileFetching.kt
+++ b/src/test/kotlin/com/arnyminerz/escalaralcoiaicomtat/backend/server/endpoints/files/TestFileFetching.kt
@@ -23,6 +23,7 @@ class TestFileFetching : ApplicationTestBase() {
         get("/file/${area.image.name}").apply {
             assertSuccess { data ->
                 assertNotNull(data)
+                assertTrue(data.has("uuid"))
                 assertTrue(data.has("hash"))
                 assertTrue(data.has("filename"))
                 assertTrue(data.has("download"))
@@ -57,6 +58,7 @@ class TestFileFetching : ApplicationTestBase() {
                 (0 until files.length())
                     .map { files.getJSONObject(it) }
                     .forEach { file ->
+                        assertTrue(file.has("uuid"))
                         assertTrue(file.has("hash"))
                         assertTrue(file.has("filename"))
                         assertTrue(file.has("download"))


### PR DESCRIPTION
All requests to `file` now will include an extra parameter called `uuid`, which is simply the UUID of the file requested.